### PR TITLE
Add mocha test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ node_js:
   - '0.10'
 
 before_script:
-  - npm install -g jshint jscs mocha
+  - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ node_js:
   - '0.10'
 
 before_script:
-  - npm install -g jshint jscs
+  - npm install -g jshint jscs mocha

--- a/index.js
+++ b/index.js
@@ -98,11 +98,13 @@ function findTranslations(file, domain) {
           continue;
         }
 
+        var filePath = file.path === undefined ? domain + '.pot' : file.path;
+
         if (!domain || domain === functionArgs[functionArgs.length - 1]) {
           translations.push({
             key: functionCall[1],
             functionArgs: functionArgs,
-            info: path.relative('./', file.path) + ':' + (lineNumber + 1),
+            info: path.relative('./', filePath) + ':' + (lineNumber + 1),
             keyChain: keyChain(functionCall[1], functionArgs),
           });
         }
@@ -177,17 +179,21 @@ function transToPot(orig) {
   return output;
 }
 
+function isObject(obj) {
+  return Object.prototype.toString.call(obj) === '[object Object]';
+}
+
 function gulpWPpot(options) {
-  if (!options.domain && !options.destFile) {
-    throw new PluginError('gulp-wp-pot', 'destFile or domain is needed !');
+  if (options === undefined || !isObject(options)) {
+    throw new PluginError('gulp-wp-pot', 'Require a argument of type object.');
+  }
+
+  if (!options.domain) {
+    throw new PluginError('gulp-wp-pot', 'Domain option is required.');
   }
 
   if (!options.destFile) {
     options.destFile = options.domain + '.pot';
-  }
-
-  if (!options.domain && !options.package) {
-    throw new PluginError('gulp-wp-pot', 'package name or domain is needed !');
   }
 
   if (!options.package) {
@@ -200,8 +206,9 @@ function gulpWPpot(options) {
 
   // creating a stream through which each file will pass
   var stream = through.obj(function(file, enc, cb) {
+
     if (file.isStream()) {
-      throw new PluginError('gulp-wp-pot', 'Streams are not supported !');
+      throw new PluginError('gulp-wp-pot', 'Streams are not supported.');
     }
 
     if (file.isBuffer()) {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "npm run test-jshint && npm run test-jscs",
+    "test": "npm run test-mocha && npm run test-jshint && npm run test-jscs",
     "test-jshint": "jshint index.js",
-    "test-jscs": "jscs index.js"
+    "test-jscs": "jscs index.js",
+    "test-mocha": "mocha"
   },
   "files": [
     "index.js"
@@ -31,6 +32,9 @@
     "wordpress",
     "translation"
   ],
+  "devDependencies": {
+    "mocha": "*"
+  },
   "dependencies": {
     "gulp-util": "^3.0.6",
     "through2": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "email": "gulp-wp-pot@rasmusbengtsson.se",
     "url": "https://github.com/rasmusbe"
   },
-  "contributors": [{
-    "name": "Willy Bahuaud",
-    "email": "willy@wabeo.fr",
-    "url": "https://github.com/willybahuaud"
-  }],
+  "contributors": [
+    {
+      "name": "Willy Bahuaud",
+      "email": "willy@wabeo.fr",
+      "url": "https://github.com/willybahuaud"
+    }
+  ],
   "engines": {
     "node": ">=0.10.0"
   },
@@ -33,11 +35,13 @@
     "translation"
   ],
   "devDependencies": {
-    "mocha": "*"
+    "jscs": "^2.0.0",
+    "jshint": "^2.8.0",
+    "mocha": "^2.2.5",
+    "vinyl": "^0.5.1"
   },
   "dependencies": {
     "gulp-util": "^3.0.6",
-    "through2": "^2.0.0",
-    "path": "^0.11.14"
+    "through2": "^2.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+/* global describe, it */
+
+var assert = require('assert');
+var gutil  = require('gulp-util');
+var File   = require('vinyl');
+var wpPot  = require('./');
+
+describe('Arguments tests', function () {
+  it('should thrown a error without argument', function () {
+    try {
+      wpPot();
+    } catch (e) {
+      assert.equal('Require a argument of type object.', e.message);
+    }
+  });
+
+  it('should thrown a error when argument is not a object', function () {
+    try {
+      wpPot(null);
+    } catch (e) {
+      assert.equal('Require a argument of type object.', e.message);
+    }
+  });
+
+  it('should throw a error without domain', function () {
+      try {
+      wpPot({});
+    } catch (e) {
+      assert.equal('Domain option is required.', e.message);
+    }
+  });
+});
+
+describe('generate tests', function () {
+  it ('should generate a pot file from php file', function (done) {
+    var testFile = new File({
+      contents: new Buffer('<?php _e( "Name", "test" ); ?>')
+    });
+    var stream = wpPot({
+      domain: 'test'
+    });
+    stream.once('data', function (file) {
+      assert(file.isBuffer());
+      done();
+    });
+    stream.write(testFile);
+    stream.end();
+  });
+
+  it ('should generate a pot file from php file with more options', function (done) {
+    var testFile = new File({
+      contents: new Buffer('<?php _x( "Name", "the name", "test" );  ?>')
+    });
+    var stream = wpPot({
+      domain: 'test',
+      bugReport: 'http://example.com',
+      lastTranslator: 'John Doe <mail@example.com>',
+      team: 'Team Team <mail@example.com>'
+    });
+    stream.once('data', function (file) {
+      assert(file.isBuffer());
+      done();
+    });
+    stream.write(testFile);
+    stream.end();
+  });
+
+  it ('should generate a pot file from php file with _n', function (done) {
+    var testFile = new File({
+      contents: new Buffer('<?php sprintf( _n( "%s star", "%s stars", 3, "test" ), 3 ); ?>')
+    });
+    var stream = wpPot({
+      domain: 'test',
+      bugReport: 'http://example.com',
+      lastTranslator: 'John Doe <mail@example.com>',
+      team: 'Team Team <mail@example.com>'
+    });
+    stream.once('data', function (file) {
+      assert(file.isBuffer());
+      done();
+    });
+    stream.write(testFile);
+    stream.end();
+  });
+
+  it ('should generate a pot file from php file with _nx', function (done) {
+    var testFile = new File({
+      contents: new Buffer('<?php sprintf( _nx( "%s star", "%s stars", 3, "stars translation", "test" ), 3 ); ?>')
+    });
+    var stream = wpPot({
+      domain: 'test',
+      bugReport: 'http://example.com',
+      lastTranslator: 'John Doe <mail@example.com>',
+      team: 'Team Team <mail@example.com>'
+    });
+    stream.once('data', function (file) {
+      assert(file.isBuffer());
+      done();
+    });
+    stream.write(testFile);
+    stream.end();
+  });
+});


### PR DESCRIPTION
This pull request will add test for almost all code.

The first thing I did was to fix the options argument checks. You did check if `destFile` or `package` was in `options` object before you generate the value with the `domain` value.

Example code that did exists:

```js
if (!options.domain && !options.package) {
  throw new PluginError('gulp-wp-pot', 'package name or domain is needed !');
}

if (!options.package) {
  options.package = options.domain;
}
```

So I removed the checks for `destFile` and `package` since it can be generated from the `domain` value. I also added a check for if `options` argument is defined and if it's a object.

The tests is written with [mocha](https://mochajs.org) testing framework. The tests will not save the generated pot file since the tests is written with `Buffer` objects with [vinyl](https://github.com/wearefractal/vinyl) package.

You can check code coverage with [istanbul]() package.

```
$ npm install -g istanbul
$ istanbul cover _mocha -- -R spec
$ open coverage/lcov-report/index.html
```