### PR TITLE
Added support for PoEdit.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,268 +1,286 @@
 'use strict';
 
-var gutil       = require('gulp-util');
-var through     = require('through2');
-var path        = require('path');
+var gutil = require('gulp-util');
+var through = require('through2');
+var path = require('path');
 var PluginError = gutil.PluginError;
 
 function keyChain(key, functionArgs) {
-  switch (key) {
-    case '__':
-    case '_e':
-    case 'esc_attr__':
-    case 'esc_attr_e':
-    case 'esc_html__':
-    case 'esc_html_e':
-      return 'simple_' + functionArgs[0];
-    case '_x':
-    case '_ex':
-    case 'esc_attr_x':
-    case 'esc_html_x':
-      return 'context_' + functionArgs[1] +  functionArgs[0];
-    case '_n':
-    case '_n_noop':
-      return 'multiple_' + functionArgs[1] + functionArgs[0];
-    case '_nx':
-    case '_nx_noop':
-      return 'multiple_' + functionArgs[2] + functionArgs[1] + functionArgs[0];
-  }
+    switch (key) {
+        case '__':
+        case '_e':
+        case 'esc_attr__':
+        case 'esc_attr_e':
+        case 'esc_html__':
+        case 'esc_html_e':
+            return 'simple_' + functionArgs[0];
+        case '_x':
+        case '_ex':
+        case 'esc_attr_x':
+        case 'esc_html_x':
+            return 'context_' + functionArgs[1] + functionArgs[0];
+        case '_n':
+        case '_n_noop':
+            return 'multiple_' + functionArgs[1] + functionArgs[0];
+        case '_nx':
+        case '_nx_noop':
+            return 'multiple_' + functionArgs[2] + functionArgs[1] + functionArgs[0];
+    }
 }
 
 function findTranslations(file, domain) {
-  var lines             = file.contents.toString().split('\n');
-  var patternFunctionCalls = /(__|_e|esc_attr__|esc_attr_e|esc_html__|esc_html_e|_x|_ex|esc_attr_x|esc_html_x|_n|_n_noop|_nx|_nx_noop)\s*\(/g;
-  var translations                 = [];
-  var functionCall;
+    var lines = file.contents.toString().split('\n');
+    var patternFunctionCalls = /(__|_e|esc_attr__|esc_attr_e|esc_html__|esc_html_e|_x|_ex|esc_attr_x|esc_html_x|_n|_n_noop|_nx|_nx_noop)\s*\(/g;
+    var translations = [];
+    var functionCall;
 
-  lines.forEach(function(line, lineNumber) {
-    while ((functionCall = patternFunctionCalls.exec(line))) {
-      if (functionCall[0]) {
-        var functionArgs = [];
-        var openParentheses = 1;
-        var escaped = false;
-        var quote = '';
+    lines.forEach(function (line, lineNumber) {
+        while ((functionCall = patternFunctionCalls.exec(line))) {
+            if (functionCall[0]) {
+                var functionArgs = [];
+                var openParentheses = 1;
+                var escaped = false;
+                var quote = '';
 
-        var currentArgument = '';
+                var currentArgument = '';
 
-        for (var i = functionCall.index + functionCall[0].length, len = line.length; i < len; i++) {
-          var currentChar = line[i];
+                for (var i = functionCall.index + functionCall[0].length, len = line.length; i < len; i++) {
+                    var currentChar = line[i];
 
-          if (quote === '' && currentChar === ' ') {
-            escaped = false;
-            continue;
-          }
+                    if (quote === '' && currentChar === ' ') {
+                        escaped = false;
+                        continue;
+                    }
 
-          if (!escaped && quote && currentChar === quote) {
-            quote = '';
-            continue;
-          }
+                    if (!escaped && quote && currentChar === quote) {
+                        quote = '';
+                        continue;
+                    }
 
-          if (!escaped && currentChar === '\\') {
-            escaped = true;
-          }
+                    if (!escaped && currentChar === '\\') {
+                        escaped = true;
+                    }
 
-          if (!escaped && !quote && (currentChar === '\"' || currentChar === '\'')) {
-            quote = currentChar;
-            continue;
-          }
+                    if (!escaped && !quote && (currentChar === '\"' || currentChar === '\'')) {
+                        quote = currentChar;
+                        continue;
+                    }
 
-          if (!quote && currentChar === '(') {
-            openParentheses++;
-          }
+                    if (!quote && currentChar === '(') {
+                        openParentheses++;
+                    }
 
-          if (!quote && currentChar === ')') {
-            openParentheses--;
-          }
+                    if (!quote && currentChar === ')') {
+                        openParentheses--;
+                    }
 
-          if (!quote && currentChar === ',') {
-            functionArgs.push(currentArgument);
-            currentArgument = '';
-            continue;
-          }
+                    if (!quote && currentChar === ',') {
+                        functionArgs.push(currentArgument);
+                        currentArgument = '';
+                        continue;
+                    }
 
-          if (escaped) {
-            escaped = false;
-          }
+                    if (escaped) {
+                        escaped = false;
+                    }
 
-          if (openParentheses > 0) {
-            currentArgument = currentArgument + currentChar;
-          }
+                    if (openParentheses > 0) {
+                        currentArgument = currentArgument + currentChar;
+                    }
 
-          if (openParentheses === 0) {
-            functionArgs.push(currentArgument);
-            break;
-          }
+                    if (openParentheses === 0) {
+                        functionArgs.push(currentArgument);
+                        break;
+                    }
+                }
+
+                if (functionArgs.length <= 1) {
+                    continue;
+                }
+
+                var filePath = file.path === undefined ? domain + '.pot' : file.path;
+
+                if (!domain || domain === functionArgs[functionArgs.length - 1]) {
+                    translations.push({
+                        key: functionCall[1],
+                        functionArgs: functionArgs,
+                        info: path.relative('./', filePath) + ':' + (lineNumber + 1),
+                        keyChain: keyChain(functionCall[1], functionArgs),
+                    });
+                }
+            }
         }
+    });
 
-        if (functionArgs.length <= 1) {
-          continue;
-        }
-
-        var filePath = file.path === undefined ? domain + '.pot' : file.path;
-
-        if (!domain || domain === functionArgs[functionArgs.length - 1]) {
-          translations.push({
-            key: functionCall[1],
-            functionArgs: functionArgs,
-            info: path.relative('./', filePath) + ':' + (lineNumber + 1),
-            keyChain: keyChain(functionCall[1], functionArgs),
-          });
-        }
-      }
-    }
-  });
-
-  return translations;
+    return translations;
 }
 
 function transToPot(orig) {
-  // Merge duplicate
-  var buffer = {};
+    // Merge duplicate
+    var buffer = {};
 
-  orig.forEach(function(file) {
-    file.forEach(function(translation) {
-      if (buffer[translation.keyChain]) {
-        buffer[ translation.keyChain ].info += ', ' + translation.info;
-      } else {
-        buffer[ translation.keyChain ] = translation;
-      }
+    orig.forEach(function (file) {
+        file.forEach(function (translation) {
+            if (buffer[translation.keyChain]) {
+                buffer[ translation.keyChain ].info += ', ' + translation.info;
+            } else {
+                buffer[ translation.keyChain ] = translation;
+            }
+        });
     });
-  });
 
-  // Write
-  var output = [];
-  if (buffer) {
-    for (var el in buffer) {
-      if (buffer.hasOwnProperty(el)) {
-        switch (buffer[el].key) {
-          case '__':
-          case '_e':
-          case 'esc_attr__':
-          case 'esc_attr_e':
-          case 'esc_html__':
-          case 'esc_html_e':
-            output.push('#: ' + buffer[el].info);
-            output.push('msgid "' + buffer[el].functionArgs[0] + '"');
-            output.push('msgstr ""\n');
-            break;
-          case '_x':
-          case '_ex':
-          case 'esc_attr_x':
-          case 'esc_html_x':
-            output.push('#: ' + buffer[el].info);
-            output.push('msgctxt "' + buffer[el].functionArgs[1] + '"');
-            output.push('msgid "' + buffer[el].functionArgs[0] + '"');
-            output.push('msgstr ""\n');
-            break;
-          case '_n':
-          case '_n_noop':
-            output.push('#: ' + buffer[el].info);
-            output.push('msgid "' + buffer[el].functionArgs[0] + '"');
-            output.push('msgid_plural "' + buffer[el].functionArgs[1] + '"');
-            output.push('msgstr[0] ""');
-            output.push('msgstr[1] ""\n');
-            break;
-          case '_nx':
-          case '_nx_noop':
-            output.push('#: ' + buffer[el].info);
-            output.push('msgctxt "' + buffer[el].functionArgs[3] + '"');
-            output.push('msgid "' + buffer[el].functionArgs[0] + '"');
-            output.push('msgid_plural "' + buffer[el].functionArgs[1] + '"');
-            output.push('msgstr[0] ""');
-            output.push('msgstr[1] ""\n');
-            break;
+    // Write
+    var output = [];
+    if (buffer) {
+        for (var el in buffer) {
+            if (buffer.hasOwnProperty(el)) {
+                switch (buffer[el].key) {
+                    case '__':
+                    case '_e':
+                    case 'esc_attr__':
+                    case 'esc_attr_e':
+                    case 'esc_html__':
+                    case 'esc_html_e':
+                        output.push('#: ' + buffer[el].info);
+                        output.push('msgid "' + buffer[el].functionArgs[0] + '"');
+                        output.push('msgstr ""\n');
+                        break;
+                    case '_x':
+                    case '_ex':
+                    case 'esc_attr_x':
+                    case 'esc_html_x':
+                        output.push('#: ' + buffer[el].info);
+                        output.push('msgctxt "' + buffer[el].functionArgs[1] + '"');
+                        output.push('msgid "' + buffer[el].functionArgs[0] + '"');
+                        output.push('msgstr ""\n');
+                        break;
+                    case '_n':
+                    case '_n_noop':
+                        output.push('#: ' + buffer[el].info);
+                        output.push('msgid "' + buffer[el].functionArgs[0] + '"');
+                        output.push('msgid_plural "' + buffer[el].functionArgs[1] + '"');
+                        output.push('msgstr[0] ""');
+                        output.push('msgstr[1] ""\n');
+                        break;
+                    case '_nx':
+                    case '_nx_noop':
+                        output.push('#: ' + buffer[el].info);
+                        output.push('msgctxt "' + buffer[el].functionArgs[3] + '"');
+                        output.push('msgid "' + buffer[el].functionArgs[0] + '"');
+                        output.push('msgid_plural "' + buffer[el].functionArgs[1] + '"');
+                        output.push('msgstr[0] ""');
+                        output.push('msgstr[1] ""\n');
+                        break;
+                }
+            }
         }
-      }
     }
-  }
 
-  return output;
+    return output;
 }
 
 function isObject(obj) {
-  return Object.prototype.toString.call(obj) === '[object Object]';
+    return Object.prototype.toString.call(obj) === '[object Object]';
 }
 
 function gulpWPpot(options) {
-  if (options === undefined || !isObject(options)) {
-    throw new PluginError('gulp-wp-pot', 'Require a argument of type object.');
-  }
-
-  if (!options.domain) {
-    throw new PluginError('gulp-wp-pot', 'Domain option is required.');
-  }
-
-  if (!options.destFile) {
-    options.destFile = options.domain + '.pot';
-  }
-
-  if (!options.package) {
-    options.package = options.domain;
-  }
-
-  var buffer   = [];
-  var destFile = options.destFile;
-  var destDir  = path.dirname(destFile);
-
-  // creating a stream through which each file will pass
-  var stream = through.obj(function(file, enc, cb) {
-
-    if (file.isStream()) {
-      throw new PluginError('gulp-wp-pot', 'Streams are not supported.');
+    if (options === undefined || !isObject(options)) {
+        throw new PluginError('gulp-wp-pot', 'Require a argument of type object.');
     }
 
-    if (file.isBuffer()) {
-      var translations = findTranslations(file, options.domain);
-      if (translations.length > 0) {
-        buffer.push(translations);
-      }
+    if (!options.domain) {
+        throw new PluginError('gulp-wp-pot', 'Domain option is required.');
     }
 
-    cb();
-  }, function(cb) {
-
-    //Headers
-    var year = new Date().getFullYear();
-    var contents = '# Copyright (C) ' + year + ' ' + options.package + '\n';
-    contents += '# This file is distributed under the same license as the ' + options.package + ' package.\n';
-    contents += 'msgid ""\n';
-    contents += 'msgstr ""\n';
-    contents += '"Project-Id-Version: ' + options.package + '\\n"\n';
-
-    if (options.bugReport) {
-      contents += '"Report-Msgid-Bugs-To: ' + options.bugReport + '\\n"\n';
+    if (!options.destFile) {
+        options.destFile = options.domain + '.pot';
     }
 
-    contents += '"MIME-Version: 1.0\\n"\n';
-    contents += '"Content-Type: text/plain; charset=UTF-8\\n"\n';
-    contents += '"Content-Transfer-Encoding: 8bit\\n"\n';
-    contents += '"PO-Revision-Date: ' + year + '-MO-DA HO:MI+ZONE\\n"\n';
-
-    if (options.lastTranslator) {
-      contents += '"Last-Translator: ' + options.lastTranslator + '\\n"\n';
+    if (!options.package) {
+        options.package = options.domain;
     }
 
-    if (options.team) {
-      contents += '"Language-Team: ' + options.team + '\\n"\n\n';
-    }
+    var buffer = [];
+    var destFile = options.destFile;
+    var destDir = path.dirname(destFile);
 
-    contents += '"Plural-Forms: nplurals=2; plural=(n != 1);\\n\\n"\n\n';
+    // creating a stream through which each file will pass
+    var stream = through.obj(function (file, enc, cb) {
 
-    //Contents
-    buffer = transToPot(buffer);
-    contents += buffer.join('\n');
+        if (file.isStream()) {
+            throw new PluginError('gulp-wp-pot', 'Streams are not supported.');
+        }
 
-    var concatenatedFile = new gutil.File({
-      base: path.relative('./', destDir),
-      cwd: destDir,
-      path: path.join(destDir, destFile),
-      contents: new Buffer(contents),
+        if (file.isBuffer()) {
+            var translations = findTranslations(file, options.domain);
+            if (translations.length > 0) {
+                buffer.push(translations);
+            }
+        }
+
+        cb();
+    }, function (cb) {
+
+        //Headers
+        var year = new Date().getFullYear();
+        var contents = '# Copyright (C) ' + year + ' ' + options.package + '\n';
+        contents += '# This file is distributed under the same license as the ' + options.package + ' package.\n';
+        contents += 'msgid ""\n';
+        contents += 'msgstr ""\n';
+        contents += '"Project-Id-Version: ' + options.package + '\\n"\n';
+
+        if (options.bugReport) {
+            contents += '"Report-Msgid-Bugs-To: ' + options.bugReport + '\\n"\n';
+        }
+
+        contents += '"MIME-Version: 1.0\\n"\n';
+        contents += '"Content-Type: text/plain; charset=UTF-8\\n"\n';
+        contents += '"Content-Transfer-Encoding: 8bit\\n"\n';
+        contents += '"PO-Revision-Date: ' + year + '-MO-DA HO:MI+ZONE\\n"\n';
+
+        if (options.lastTranslator) {
+            contents += '"Last-Translator: ' + options.lastTranslator + '\\n"\n';
+        }
+
+        if (options.team) {
+            contents += '"Language-Team: ' + options.team + '\\n"\n\n';
+        }
+
+        if (options.poEdit) {
+
+            // If keywordsList not set, use defaults
+            if (options.poEdit.keywordsList) {
+                contents += '"X-Poedit-KeywordsList: ' + options.poEdit.keywordsList + '\\n"\n';
+            } else {
+                contents += '"X-Poedit-KeywordsList: __;_e;esc_attr__;esc_attr_e;esc_html__;esc_html_e;_x;_ex;esc_attr_x;esc_html_x;_n;_n_noop;_nx;_nx_noop\\n"\n';
+            }
+
+            if (options.poEdit.basePath) {
+                contents += '"X-Poedit-Basepath: ' + options.poEdit.basePath + '\\n"\n';
+            }
+
+            if (options.poEdit.searchPath) {
+                contents += '"X-Poedit-SearchPath-0: ' + options.poEdit.searchPath + '\\n"\n\n';
+            }
+        }
+
+        contents += '"Plural-Forms: nplurals=2; plural=(n != 1);\\n\\n"\n\n';
+
+        //Contents
+        buffer = transToPot(buffer);
+        contents += buffer.join('\n');
+
+        var concatenatedFile = new gutil.File({
+            base: path.relative('./', destDir),
+            cwd: destDir,
+            path: path.join(destDir, destFile),
+            contents: new Buffer(contents),
+        });
+        this.push(concatenatedFile);
+        cb();
     });
-    this.push(concatenatedFile);
-    cb();
-  });
 
-  return stream;
+    return stream;
 }
 
 module.exports = gulpWPpot;

--- a/nbproject/private/private.properties
+++ b/nbproject/private/private.properties
@@ -1,0 +1,1 @@
+browser=Chrome.INTEGRATED

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,0 +1,3 @@
+files.encoding=UTF-8
+site.root.folder=
+source.folder=

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.web.clientproject</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/clientside-project/1">
+            <name>gulp-wp-pot</name>
+        </data>
+    </configuration>
+</project>


### PR DESCRIPTION
Hi,

Thanks for nice plugin. I am using it to generate .pot files for our themes but when generating using this plugin, I need to manually enter PoEdit specific parameters. PoEdit is very popular translation tools so I though about adding support by adding options to plugin for three specific parameters ("keywords", "base" and "search path") that will be automatically added to the header of .pot file.

This allows updating .pot file from PoEdit (Cataloque ->Update from sources) for those who changed theme files and don't have access to gulp (most non-devs).

So I added PoEdit support to your plugin. It adds three lines mentioned above to header. It should be used like below:
```
gulp.task('default', function () {
    return gulp.src('src/file.php')
        .pipe(wpPot( {
            domain: 'domain',
            destFile:'file.pot',
            package: 'package_name',
            bugReport: 'http://example.com',
            lastTranslator: 'First Last <mail@example.com>',
            team: 'Team <mail@example.com>',
            poEdit: {
                keywordsList: '_;gettext;gettext_noop;__;_e;esc_attr_e;esc_html_e',
                basePath: '.',
                searchPath: '..'
            }
        } ))
        .pipe(gulp.dest('dist'));
});
```

If "keywordsList" is not set, default will be used:
```
__;_e;esc_attr__;esc_attr_e;esc_html__;esc_html_e;_x;_ex;esc_attr_x;esc_html_x;_n;_n_noop;_nx;_nx_noop
```

I think this is nice addition for those who need quick compatibility with PoEdit.

Vladimir