### PR TITLE
Add a blank line after headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -371,6 +371,7 @@ function gulpWPpot(options) {
     }
 
     contents += '"Plural-Forms: nplurals=2; plural=(n != 1);\\n"\n';
+    contents += '\n';
 
     // Contents.
     var translations = uniqueTranslations(translationsBuffer);


### PR DESCRIPTION
Add a blank line to separate headers with the first real msgid. Without it some poedit versions get troubles.